### PR TITLE
Cypress/E2E: Add license file path environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run:
 	docker run --net mattermost-e2e_mm-test --rm appropriate/curl:latest sh -c "until curl --max-time 5 --output - http://webhook:3000; do echo waiting for webhook; sleep 5; done;"
 	@echo --- webhook: confirmed running
 
-	# docker run --net mattermost-e2e_mm-test --rm --name mattermost-e2e_cypress -e CYPRESS_baseUrl=http://app:8000 -e CYPRESS_webhookBaseUrl=http://webhook:3000 mattermost-e2e/cypress
+	# docker run --net mattermost-e2e_mm-test --rm --name mattermost-e2e_cypress -e CYPRESS_baseUrl=http://app:8000 -e CYPRESS_webhookBaseUrl=http://webhook:3000 mattermost-e2e/cypress -e CYPRESS_licenseFilePath=mm-license.txt
 	# @echo --- Cypress tests: completed
 
 stop:

--- a/mattermost-e2e/cypress/Dockerfile
+++ b/mattermost-e2e/cypress/Dockerfile
@@ -2,6 +2,7 @@ FROM cypress/browsers:node10.16.3-chrome80-ff73
 
 ENV CYPRESS_baseUrl=$CYPRESS_baseUrl
 ENV CYPRESS_webhookBaseUrl=$CYPRESS_webhookBaseUrl
+ENV CYPRESS_licenseFilePath=$CYPRESS_licenseFilePath
 
 # # avoid too many progress messages
 # # https://github.com/cypress-io/cypress/issues/1243


### PR DESCRIPTION
#### Summary
- Added `CYPRESS_licenseFilePath` environment variable to be used for uploading license file to server via API
- Looks like the docker run for the cypress test suite is commented out in `Makefile`; not sure what command is issued on Circle/CI -- @saturninoabril I'll let you modify it on Circle/CI or please comment about the steps here

This PR blocks https://github.com/mattermost/mattermost-webapp/pull/6101

#### Ticket Link
None -  master only