### PR TITLE
Cypress/E2E: Propagate step status to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
 
-            cd e2e && node run_tests.js --group='@plugin_marketplace' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
+            cd e2e && node run_tests.js --group='@commands' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - run:
           name: Save and publish reports
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,10 @@ jobs:
             export CYPRESS_resetBeforeTest=true
             export CYPRESS_runLDAPSync=false
 
-            cd e2e && node run_tests.js --stage='@prod'
-
+            cd e2e && node run_tests.js --group='@plugin_marketplace'
       - run:
           name: Save and publish reports
+          where: always
           command: |
             export DIAGNOSTIC_USER_ID=`psql -d $TEST_DATABASE_URL -t -c "SELECT id FROM users WHERE username='sysadmin';"`
             export DIAGNOSTIC_TEAM_ID=`psql -d $TEST_DATABASE_URL -t -c "SELECT id FROM teams WHERE name='ad-1';"`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
             cd e2e && node run_tests.js --group='@plugin_marketplace' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - run:
           name: Save and publish reports
-          where: always
+          when: always
           command: |
             export DIAGNOSTIC_USER_ID=`psql -d $TEST_DATABASE_URL -t -c "SELECT id FROM users WHERE username='sysadmin';"`
             export DIAGNOSTIC_TEAM_ID=`psql -d $TEST_DATABASE_URL -t -c "SELECT id FROM teams WHERE name='ad-1';"`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
           name: Run Cypress Test
           no_output_timeout: 30m
           command: |
+            set -e 
             cd e2e && nohup node webhook_serve.js > webhook_serve.log &
 
             export CYPRESS_chromeWebSecurity=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
           name: Run Cypress Test
           no_output_timeout: 30m
           command: |
-            set -e 
             cd e2e && nohup node webhook_serve.js > webhook_serve.log &
 
             export CYPRESS_chromeWebSecurity=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
 
-            cd e2e && node run_tests.js --group='@commands' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
+            cd e2e && node run_tests.js --stage='@prod' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - run:
           name: Save and publish reports
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,10 @@ jobs:
             export CYPRESS_dbConnection="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
             export CYPRESS_resetBeforeTest=true
             export CYPRESS_runLDAPSync=false
+            export FAILURE_MESSAGE="At least one test has failed."
+            export RESULTS_OUTPUT="results-output.txt"
 
-            cd e2e && node run_tests.js --group='@plugin_marketplace'
+            cd e2e && node run_tests.js --group='@plugin_marketplace' |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - run:
           name: Save and publish reports
           where: always

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,6 +5,7 @@
     "async": "3.2.0",
     "aws-sdk": "2.732.0",
     "axios": "0.19.2",
+    "chai": "4.2.0",
     "chalk": "4.1.0",
     "cypress": "4.12.1",
     "cypress-file-upload": "4.0.7",

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -58,6 +58,7 @@ async function runTests() {
         ENABLE_VISUAL_TEST,
         APPLITOOLS_API_KEY,
         APPLITOOLS_BATCH_NAME,
+        FAILURE_MESSAGE,
     } = process.env;
 
     const browser = BROWSER || 'chrome';
@@ -142,7 +143,7 @@ async function runTests() {
         }
     }
 
-    chai.expect(hasFailed, 'At least one test has failed.').to.be.false;
+    chai.expect(hasFailed, FAILURE_MESSAGE).to.be.false;
 }
 
 runTests();

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -38,7 +38,7 @@
  */
 
 const os = require('os');
-
+const chai = require('chai');
 const chalk = require('chalk');
 const cypress = require('cypress');
 const argv = require('yargs').argv;
@@ -73,6 +73,7 @@ async function runTests() {
 
     const {invert, group, stage} = argv;
 
+    let hasFailed = false;
     for (let i = 0; i < finalTestFiles.length; i++) {
         const testFile = finalTestFiles[i];
         const testStage = stage ? `Stage: "${stage}" ` : '';
@@ -135,7 +136,13 @@ async function runTests() {
 
             writeJsonToFile(environment, 'environment.json', RESULTS_DIR);
         }
+
+        if (!hasFailed && result.totalFailed > 0) {
+            hasFailed = true;
+        }
     }
+
+    chai.expect(hasFailed, 'At least one test has failed.').to.be.false;
 }
 
 runTests();


### PR DESCRIPTION
This is so we can verify build run status at a glance (no false positives).

- Added new environment variables for run test step
- Added check for `run_test.js` result and `exit 1` if at least one failure
- Added `when: always` to save report step to always run it even if previous step failed
- [Ran success and failure scenarios here.](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=run-test-step-status)
See runs,
`Test Run - At least one test failed - Expected: FAIL; fixed typo`
`Test Run - No failure - Expected: SUCCEED`